### PR TITLE
feat(Flex): flex 컴포넌트를 원하는 컴포넌트로 렌더할 수 있도록 수정

### DIFF
--- a/src/components/Flex/index.tsx
+++ b/src/components/Flex/index.tsx
@@ -7,13 +7,25 @@ export interface FlexBaseProps {
   justify?: CSSProperties['justifyContent'];
 }
 
+export const DEFAULT_ELEMENT = 'div' as const;
+
 type Props<T extends ElementType = 'div'> = OverridableProps<T, FlexBaseProps>;
 const Flex = <T extends ElementType = 'div'>(
-  { direction = 'row', align = 'flex-start', justify = 'flex-start', children, ...rest }: Props<T>,
+  {
+    direction = 'row',
+    align = 'flex-start',
+    justify = 'flex-start',
+    children,
+    as,
+    ...rest
+  }: Props<T>,
   ref: Ref<any>
 ) => {
+  const target = as ?? DEFAULT_ELEMENT;
+  const Component = target;
+
   return (
-    <div
+    <Component
       ref={ref}
       css={{
         display: 'flex',
@@ -24,7 +36,7 @@ const Flex = <T extends ElementType = 'div'>(
       {...rest}
     >
       {children}
-    </div>
+    </Component>
   );
 };
 


### PR DESCRIPTION
## 변경사항

`Flex` 컴포넌트가 `as` Props는 받고 있는데 쓰지를 않고 있었네요. 이 값을 이용하여 `Flex` 를 사용할 때 원하는 컴포넌트로 렌더할 수 있게끔 변경합니다.

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇 