### PR TITLE
fix(overlay): 브라우저 API가 디펜던시 어레이에 들어가 있는 이슈 수정

### DIFF
--- a/src/contexts/Overlay/OverlayContext.tsx
+++ b/src/contexts/Overlay/OverlayContext.tsx
@@ -43,7 +43,7 @@ function OverlayProvider({ children }: PropsWithChildren<unknown>) {
       addToArea,
       removeFromArea,
     }),
-    [open, close]
+    [addToArea, removeFromArea]
   );
 
   return (

--- a/src/stories/Hooks/useOverlay/components.tsx
+++ b/src/stories/Hooks/useOverlay/components.tsx
@@ -1,0 +1,27 @@
+import { useEffect } from 'react';
+import { useOverlay } from 'src';
+
+export function useOverlayModal() {
+  const { createOverlayElement, open, close, destroy } = useOverlay();
+  useEffect(() => {
+    createOverlayElement(({ isOpen, close }) => {
+      return (
+        <div style={{ display: isOpen ? 'block' : 'none' }}>
+          모달입니다.
+          <button onClick={close}>닫기</button>
+        </div>
+      );
+    });
+
+    return () => {
+      destroy();
+    };
+  }, []);
+
+  return { openModal: open, closeModal: close, destroyModal: destroy };
+}
+
+export function OverlayStory() {
+  const { openModal } = useOverlayModal();
+  return <button onClick={openModal}>모달 열기</button>;
+}

--- a/src/stories/Hooks/useOverlay/index.stories.mdx
+++ b/src/stories/Hooks/useOverlay/index.stories.mdx
@@ -1,0 +1,16 @@
+import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
+import { OverlayStory } from './components';
+
+<Meta title="Hooks/Overlay" />
+
+# Overlay
+
+`Overlay`
+
+# Preview
+
+<Canvas>
+  <Story name="useOverlay">
+    <OverlayStory />
+  </Story>
+</Canvas>


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(Tooltip): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 변경사항
`OverlayContext` 내부에 있는 `value`의 메모아이제이션 기준으로 브라우저 API인 `open`, `close`가 포함되어 있는 버그를 수정합니다.

<!-- 
ex.
### Tooltip
- 엘리먼트 포지션을 루트 기반으로 계산하도록 수정
### Skeleton
- 그라데이션 애니메이션 렌더 시 Repaint 없도록 수정
-->

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇 