### PR TITLE
feat(useOverlay): createOverlayElement 없이도 overlay를 사용할 수 있도록 수정

### DIFF
--- a/src/contexts/Overlay/StateReacter.tsx
+++ b/src/contexts/Overlay/StateReacter.tsx
@@ -9,7 +9,7 @@ const StateReacter = forwardRef<any, { controller: OverlayController }>(function
   { controller },
   ref
 ) {
-  const [isOpen, setOpen] = useState(false);
+  const [isOpen, setOpen] = useState(true);
   const open = useCallback(() => setOpen(true), []);
   const close = useCallback(() => setOpen(false), []);
 

--- a/src/stories/Hooks/useOverlay/components.tsx
+++ b/src/stories/Hooks/useOverlay/components.tsx
@@ -1,27 +1,56 @@
-import { useEffect } from 'react';
 import { useOverlay } from 'src';
 
-export function useOverlayModal() {
-  const { createOverlayElement, open, close, destroy } = useOverlay();
-  useEffect(() => {
-    createOverlayElement(({ isOpen, close }) => {
-      return (
-        <div style={{ display: isOpen ? 'block' : 'none' }}>
-          모달입니다.
-          <button onClick={close}>닫기</button>
-        </div>
-      );
-    });
-
-    return () => {
-      destroy();
-    };
-  }, []);
-
-  return { openModal: open, closeModal: close, destroyModal: destroy };
+export function OverlayStory() {
+  const { open } = useOverlay();
+  return (
+    <button
+      onClick={() => {
+        open(({ isOpen, close }) => {
+          return (
+            <div style={{ display: isOpen ? 'block' : 'none' }}>
+              모달입니다.
+              <button onClick={close}>닫기</button>
+            </div>
+          );
+        });
+      }}
+    >
+      모달 열기
+    </button>
+  );
 }
 
-export function OverlayStory() {
-  const { openModal } = useOverlayModal();
-  return <button onClick={openModal}>모달 열기</button>;
+export function OverlayWithPromiseStory() {
+  const { open } = useOverlay();
+
+  const openModal = () => {
+    return new Promise<void>((resolve) => {
+      open(({ isOpen, close }) => {
+        return (
+          <div style={{ display: isOpen ? 'block' : 'none' }}>
+            모달입니다.
+            <button
+              onClick={() => {
+                close();
+                resolve();
+              }}
+            >
+              닫기
+            </button>
+          </div>
+        );
+      });
+    });
+  };
+
+  return (
+    <button
+      onClick={async () => {
+        await openModal();
+        alert('모달 닫힘');
+      }}
+    >
+      모달 열기
+    </button>
+  );
 }

--- a/src/stories/Hooks/useOverlay/index.stories.mdx
+++ b/src/stories/Hooks/useOverlay/index.stories.mdx
@@ -1,5 +1,5 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
-import { OverlayStory } from './components';
+import { OverlayStory, OverlayWithPromiseStory } from './components';
 
 <Meta title="Hooks/Overlay" />
 
@@ -12,5 +12,13 @@ import { OverlayStory } from './components';
 <Canvas>
   <Story name="useOverlay">
     <OverlayStory />
+  </Story>
+</Canvas>
+
+# With Promise
+
+<Canvas>
+  <Story name="useOverlay With Promise">
+    <OverlayWithPromiseStory />
   </Story>
 </Canvas>


### PR DESCRIPTION
<!-- 이 PR이 BREAKING_CHANGE를 포함하고 있다면 반드시 명시해주세요! -->
<!-- PR 타이틀을 "feat(Tooltip): ~~를 변경한 PR" 처럼 Conventional Commit 포맷으로 맞춰주세요! -->

## 변경사항

`useOverlay`를 사용할 때 매번 `useEffect` 훅 내에서 `createOverlayElement`를 사용하는 방식을 개선하여, `open` 함수만으로 오버레이를 사용할 수 있도록 변경합니다.

### Example

```tsx
const { open } = useOverlay();
  return (
    <button
      onClick={() => {
        open(({ isOpen, close }) => {
          return (
            <div style={{ display: isOpen ? 'block' : 'none' }}>
              모달입니다.
              <button onClick={close}>닫기</button>
            </div>
          );
        });
      }}
    >
      모달 열기
    </button>
  );
```

### With Promise

```tsx
const { open } = useOverlay();

  const openModal = () => {
    return new Promise<void>((resolve) => {
      open(({ isOpen, close }) => {
        return (
          <div style={{ display: isOpen ? 'block' : 'none' }}>
            모달입니다.
            <button
              onClick={() => {
                close();
                resolve();
              }}
            >
              닫기
            </button>
          </div>
        );
      });
    });
  };

  return (
    <button
      onClick={async () => {
        await openModal();
        alert('모달 닫힘');
      }}
    >
      모달 열기
    </button>
  );
```

## 집중적으로 리뷰 받고 싶은 부분이 있나요?
🙇 